### PR TITLE
Fix import error during setup

### DIFF
--- a/sitemapext/views.py
+++ b/sitemapext/views.py
@@ -3,11 +3,22 @@ from random import randint
 from django.conf import settings
 from django.http import HttpResponse, Http404, HttpResponseForbidden
 from django.core.urlresolvers import reverse
-from django.utils.cache import patch_response_headers
-from django.views.decorators.cache import cache_page, never_cache
+
+try:
+    from django.core.exceptions import ImproperlyConfigured
+    importing_exceptions = (ImportError, ImproperlyConfigured)
+except ImportError:
+    pass
+
+try:
+    from django.utils.cache import patch_response_headers
+    from django.views.decorators.cache import cache_page, never_cache
+except importing_exceptions:
+    pass
+
 try:
     from django.views.generic import ListView, View
-except ImportError:
+except importing_exceptions:
     try:
         from cbv import ListView, View
     except ImportError:


### PR DESCRIPTION
During setup you don't have DJANGO_SETTINGS_MODULE at the enviroment. Because of this the setup.py crashes.
This PR fixes that using try-catch statements.

I don't know how create an unit test for this, i just tested at my machine. 

The error i was getting was

```
Running setup.py egg_info for package django-sitemap-extras
    Traceback (most recent call last):
      File "<string>", line 16, in <module>
      File "/Users/thiago/.virtualenv/metapix/build/django-sitemap-extras/setup.py", line 4, in <module>
        from sitemapext import __version__
      File "sitemapext/__init__.py", line 2, in <module>
        from .views import (SitemapGenerator, SitemapIndex, SitemapView, VideoSitemapView, ImageSitemapView,
      File "sitemapext/views.py", line 6, in <module>
        from django.utils.cache import patch_response_headers
      File "/Users/thiago/.virtualenv/metapix/lib/python2.7/site-packages/django/utils/cache.py", line 26, in <module>
        from django.core.cache import get_cache
      File "/Users/thiago/.virtualenv/metapix/lib/python2.7/site-packages/django/core/cache/__init__.py", line 69, in <module>
        if DEFAULT_CACHE_ALIAS not in settings.CACHES:
      File "/Users/thiago/.virtualenv/metapix/lib/python2.7/site-packages/django/conf/__init__.py", line 54, in __getattr__
        self._setup(name)
      File "/Users/thiago/.virtualenv/metapix/lib/python2.7/site-packages/django/conf/__init__.py", line 47, in _setup
        % (desc, ENVIRONMENT_VARIABLE))
    django.core.exceptions.ImproperlyConfigured: Requested setting CACHES, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 16, in <module>

  File "/Users/thiago/.virtualenv/metapix/build/django-sitemap-extras/setup.py", line 4, in <module>

    from sitemapext import __version__

  File "sitemapext/__init__.py", line 2, in <module>

    from .views import (SitemapGenerator, SitemapIndex, SitemapView, VideoSitemapView, ImageSitemapView,

  File "sitemapext/views.py", line 6, in <module>

    from django.utils.cache import patch_response_headers

  File "/Users/thiago/.virtualenv/metapix/lib/python2.7/site-packages/django/utils/cache.py", line 26, in <module>

    from django.core.cache import get_cache

  File "/Users/thiago/.virtualenv/metapix/lib/python2.7/site-packages/django/core/cache/__init__.py", line 69, in <module>

    if DEFAULT_CACHE_ALIAS not in settings.CACHES:

  File "/Users/thiago/.virtualenv/metapix/lib/python2.7/site-packages/django/conf/__init__.py", line 54, in __getattr__

    self._setup(name)

  File "/Users/thiago/.virtualenv/metapix/lib/python2.7/site-packages/django/conf/__init__.py", line 47, in _setup

    % (desc, ENVIRONMENT_VARIABLE))

django.core.exceptions.ImproperlyConfigured: Requested setting CACHES, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
```
